### PR TITLE
Permit overriding defaullt OS

### DIFF
--- a/bin/wkhtmltopdf
+++ b/bin/wkhtmltopdf
@@ -40,6 +40,8 @@ suffix = case RbConfig::CONFIG['host_os']
          else
            'unknown'
          end
+         
+suffix = ENV['WKHTMLTOPDF_HOST_SUFFIX'] unless ENV['WKHTMLTOPDF_HOST_SUFFIX'].to_s.empty?
 
 binary = "#{__FILE__}_#{suffix}"
 


### PR DESCRIPTION
Adds the `WKHTMLTOPDF_HOST_SUFFIX` environment variable which can be used to override the default OS selection code. This allows users of non-standard, but compatible OS's to force the selection of the correct `wkhtmltopdf` binary